### PR TITLE
Use ScriptableObjects as state machine triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ crashlytics-build.properties
 /Assets/AddressableAssetsData/iOS*
 /Assets/AddressableAssetsData/Android*
 /Assets/AddressableAssetsData/WindowsUniversal*
+
+# Work in progress ignores
+wipignore/
+wipignore.meta

--- a/Assets/Scripts/Core/StateMachine/Trigger.cs
+++ b/Assets/Scripts/Core/StateMachine/Trigger.cs
@@ -1,0 +1,13 @@
+// Copyright 2023 0x4448
+// SPDX-License-Identifier: Apache-2.0
+
+using UnityEngine;
+
+namespace UnitySamples
+{
+    /// <summary>
+    /// A ScriptableObject with no additional implementation that can be used as a strigger.
+    /// </summary>
+    [CreateAssetMenu(fileName = "NewTrigger", menuName = "Triggers/Trigger")]
+    public class Trigger : ScriptableObject { }
+}

--- a/Assets/Scripts/Core/StateMachine/Trigger.cs.meta
+++ b/Assets/Scripts/Core/StateMachine/Trigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21a435929a17d024ab360557d2ab0c90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Enums can't be reordered or deleted without breaking serialization, so they aren't suitable for triggers.